### PR TITLE
升级AMD parse的版本号到支持 module:// 的 AMD 依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"email": "anhulife@gmail.com"
 	},
 	"dependencies": {
-		"miaow-amd-parse": "~4.5.0",
+		"miaow-amd-parse": "~4.6.0",
 		"miaow-babel-parse": "~1.1.0",
 		"miaow-css-autoprefixer": "~1.1.0",
 		"miaow-ftl-parse": "~2.2.0",


### PR DESCRIPTION
升级AMD parse的版本号到支持 module:// 的 AMD 依赖
